### PR TITLE
Prevent status update when the status is the same

### DIFF
--- a/src/SyncStatusOnPostUpdate.php
+++ b/src/SyncStatusOnPostUpdate.php
@@ -41,7 +41,7 @@ class SyncStatusOnPostUpdate {
 		);
 
 		// Prevent running logic if the old and new status are the same
-		if ( $new_status == $old_status ) {
+		if ( $new_status === $old_status ) {
 			return;
 		}
 

--- a/src/SyncStatusOnPostUpdate.php
+++ b/src/SyncStatusOnPostUpdate.php
@@ -40,6 +40,11 @@ class SyncStatusOnPostUpdate {
 			Fns::map( Obj::prop( 'element_id' ) )
 		);
 
+		// Prevent running logic if the old and new status are the same
+		if ( $new_status == $old_status ) {
+			return;
+		}
+
 		// The current post is not the original or has no translations
 		if ( ! $getPostsToUpdate( $post->ID ) ) {
 			return;


### PR DESCRIPTION
This fixes performance issues when the new status is the same as the old one - mainly caused on update and when many translations are involved.