### PR TITLE
[wpmlsupp-12650] Performance review.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,9 @@ However, you can configure the post types to keep in sync using one or both opti
 - Hook to the `wpml_synchronize_post_status_post_types` filter. This filter receives the current list of post types.  
   Example: `add_filter( 'wpml_synchronize_post_status_post_types', function( $allowed_post_types ) { return array_merge($allowed_post_types, [ 'products' ]); } )`
 
+You can also blacklist post types so they are not synchronized:
+
+- Hook to the `wpml_synchronize_post_status_post_types_exclude` filter. This filter receives the current list of post types to exclude.  
+  Example: `add_filter( 'wpml_synchronize_post_status_post_types_exclude', function( $excluded_post_types ) { return array_merge($excluded_post_types, [ 'books' ]); } )`
+
 By default, the array of allowed posts types is empty. That means that all post types will be kept in sync.

--- a/plugin.php
+++ b/plugin.php
@@ -8,14 +8,19 @@ Author: Andrea Sciamanna
 Author URI: https://www.onthegosystems.com/team/andrea-sciamanna/
 */
 
-namespace WPML\Core;
-
-// don't load directly
+// Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-require_once __DIR__ . '/src/SyncStatusOnPostUpdate.php';
+add_action( 'plugins_loaded', 'checkWPMLSPSrequirements' );
 
-$syncStatusOnPostUpdate = new SyncStatusOnPostUpdate();
-$syncStatusOnPostUpdate->init_hooks();
+function checkWPMLSPSrequirements() {
+	if ( ! defined( 'ICL_SITEPRESS_VERSION' ) ) {
+		return;
+	}
+	require_once __DIR__ . '/src/SyncStatusOnPostUpdate.php';
+
+	$syncStatusOnPostUpdate = new \WPML\Core\SyncStatusOnPostUpdate();
+	$syncStatusOnPostUpdate->init_hooks();
+}

--- a/src/SyncStatusOnPostUpdate.php
+++ b/src/SyncStatusOnPostUpdate.php
@@ -7,25 +7,44 @@ use WPML\FP\Obj;
 use function WPML\FP\pipe;
 
 class SyncStatusOnPostUpdate {
-	private $allowed_post_types;
 
-	/**
-	 * SyncStatusOnPostUpdate constructor.
-	 */
-	public function __construct() {
-		$this->allowed_post_types = [];
-		if ( defined( "WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES" ) ) {
-			if ( is_string( WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES ) ) {
-				$this->allowed_post_types =  explode( ',', WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES );
-			} else {
-				$this->allowed_post_types = WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES;
-			}
-		}
-		$this->allowed_post_types = apply_filters( 'wpml_synchronize_post_status_post_types', $this->allowed_post_types );
-	}
+	/** @var string[]|null */
+	private $allowed_post_types;
+	/** @var string[]|null */
+	private $disallowed_post_types;
+	/** @var int[] */
+	private $idsToSkip = [];
 
 	public function init_hooks() {
 		add_action( 'transition_post_status', [ $this, 'on_post_status_change' ], 10, 3 );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function set_allowed_post_types() {
+		if ( null === $this->allowed_post_types ) {
+			$this->allowed_post_types = [];
+			if ( defined( "WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES" ) ) {
+				if ( is_string( WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES ) ) {
+					$this->allowed_post_types =  explode( ',', WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES );
+				} elseif ( is_array( WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES ) ) {
+					$this->allowed_post_types = WPML_SYNCHRONIZE_POST_STATUS_POST_TYPES;
+				}
+			}
+			$this->allowed_post_types = apply_filters( 'wpml_synchronize_post_status_post_types', $this->allowed_post_types );
+		}
+		return $this->allowed_post_types;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function set_disallowed_post_types() {
+		if ( null === $this->disallowed_post_types ) {
+			$this->disallowed_post_types = apply_filters( 'wpml_synchronize_post_status_post_types_exclude', [] );
+		}
+		return $this->disallowed_post_types;
 	}
 
 	/**
@@ -34,38 +53,67 @@ class SyncStatusOnPostUpdate {
 	 * @param \WP_Post $post
 	 */
 	public function on_post_status_change( $new_status, $old_status, $post ) {
+		// Prevent running the logic if the old and new status are the same.
+		if ( $new_status === $old_status ) {
+			return;
+		}
+
+		// Prevent running the logic if the post was inserted anew using the wp_insert_post function:
+		// most probably, it does not have a language assigned yet, and translations are created with the same status as their originals.
+		if ( 'new' === $old_status ) {
+			return;
+		}
+
+		// This is a translation, and the original post was already processed.
+		if ( in_array( (int) $post->ID, $this->idsToSkip, true ) ) {
+			return;
+		}
+
+		// Include selected post types, or all, and skip selected post types.
+		$this->set_allowed_post_types();
+		if ( count( $this->allowed_post_types ) > 0 && ! in_array( $post->post_type, $this->allowed_post_types, true ) ) {
+			return;
+		}
+		$this->set_disallowed_post_types();
+		if ( in_array( $post->post_type, $this->disallowed_post_types, true ) ) {
+			return;
+		}
+
 		$getPostsToUpdate = pipe(
 			\WPML\Element\API\PostTranslations::getIfOriginal(),
 			Fns::reject( Obj::prop( 'original' ) ),
 			Fns::map( Obj::prop( 'element_id' ) )
 		);
 
-		// Prevent running logic if the old and new status are the same
-		if ( $new_status === $old_status ) {
+		// The current post is not the original or has no translations.
+		$translationIds = $getPostsToUpdate( $post->ID );
+		if ( ! $translationIds ) {
 			return;
 		}
 
-		// The current post is not the original or has no translations
-		if ( ! $getPostsToUpdate( $post->ID ) ) {
-			return;
-		}
+		$translationIds  = array_map( 'intval', $translationIds );
+		$this->idsToSkip = array_merge( $this->idsToSkip, $translationIds );
 
-		if ( count( $this->allowed_post_types ) > 0 && ! in_array( $post->post_type, $this->allowed_post_types, true ) ) {
-			return;
-		}
+		// Update the status in the database.
+		global $wpdb;
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->posts}
+				SET post_status = %s
+				WHERE ID IN  (" . wpml_prepare_in( $translationIds, '%d' ) . ")",
+				$new_status
+			)
+		);
 
-		global $sitepress;
-
-		$element_type = 'post_' . $post->post_type;
-		if ( $post->ID == $sitepress->get_original_element_id( $post->ID, $element_type ) ) {
-			$trid         = $sitepress->get_element_trid( $post->ID, $element_type );
-			$translations = $sitepress->get_element_translations( $trid, $element_type );
-
-			foreach ( $translations as $source_language_code => $translation_data ) {
-				if ( (int) $translation_data->element_id !== $post->ID ) {
-					wp_update_post( [ 'ID' => $translation_data->element_id, 'post_status' => $new_status ] );
-				}
+		// Avoid recursion.
+		remove_action( 'transition_post_status', [ $this, 'on_post_status_change' ], 10 );
+		foreach ( $translationIds as $translationId ) {
+			$translationPost = get_post( $translationId );
+			if ( $translationPost ) {
+				// Trigger the actions related to the transitioning of a post's status.
+				wp_transition_post_status( $new_status, $old_status, $translationPost );
 			}
 		}
+		add_action( 'transition_post_status', [ $this, 'on_post_status_change' ], 10, 3 );
 	}
 }


### PR DESCRIPTION
- Avoid recursion.
- Support blacklisting post types.
- Get translations only once.
- Update statis in one database operation.
- On update, fire only actions related to changes in post status.

Also, only load the logic if WPML is active.